### PR TITLE
Revert "grid.updateColumnHeader now updates the header css."

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,6 @@ easier to work with multiple grid instances and pinned columns.
     API only allows for a whole grid redraw, which can be very slow. Pull request with notes
     [here](https://github.com/mleibman/SlickGrid/pull/897). Use cases for fast column size adjustment may be:
     auto-sizing columns to fit content, responsive sizing cells to fill the screen, and similar.
-* `grid.updateColumnHeader`
-  * when called, also ensures that column.headerCssClass gets applied to the header DOM element
-  * motivation: <1ms per column, versus 100-200ms when calling grid.setColumns()
-* `grid.updateColumnHeaders`
-  * calls `grid.updateColumnHeader` for all columns
 * `grid.getId()` lets you get the uid of the grid instance
 * `grid.isGroupNode(row, cell)` lets you check if a node is part of a group row
 * Triggers existing event `onColumnsResized` when you change the column widths

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -632,12 +632,6 @@
       $boundAncestors = null;
     }
 
-    function updateColumnHeaders() {
-      for (var i = 0; i < columns.length; i++) {
-        updateColumnHeader(columns[i].id);
-      }
-    }
-
     function updateColumnHeader(columnId, title, toolTip) {
       if (!initialized) { return; }
       var idx = getColumnIndex(columnId);
@@ -660,9 +654,6 @@
 
         $header
           .attr("title", toolTip || "")
-          .removeClass($header.data("headerCssClass"))
-          .addClass(columnDef.headerCssClass || "")
-          .data("headerCssClass", columnDef.headerCssClass)
           .children().eq(0).html(title);
 
         trigger(self.onHeaderCellRendered, {
@@ -763,7 +754,6 @@
           .attr("title", m.toolTip || "")
           .data("column", m)
           .addClass(m.headerCssClass || "")
-          .data("headerCssClass", m.headerCssClass)
           .addClass(hiddenClass)
           .bind("dragstart", { distance: 3 }, function(e, dd) {
             trigger(self.onHeaderColumnDragStart, { "origEvent": e, "dragData": dd, "node": this, "columnIndex": getColumnIndexFromEvent(e) })
@@ -4019,7 +4009,6 @@
       "getColumnIndex": getColumnIndex,
       "getColumnNodeById": getColumnNodeById,
       "updateColumnHeader": updateColumnHeader,
-      "updateColumnHeaders": updateColumnHeaders,
       "refreshColumns": refreshColumns,
       "hideColumn": hideColumn,
       "unhideColumn": unhideColumn,


### PR DESCRIPTION
Reverts coatue/SlickGrid#5
