### PR TITLE
grid.updateColumnHeader now updates the header css

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ easier to work with multiple grid instances and pinned columns.
     API only allows for a whole grid redraw, which can be very slow. Pull request with notes
     [here](https://github.com/mleibman/SlickGrid/pull/897). Use cases for fast column size adjustment may be:
     auto-sizing columns to fit content, responsive sizing cells to fill the screen, and similar.
+* `grid.updateColumnHeader`
+  * when called, also ensures that column.headerCssClass gets applied to the header DOM element
+  * motivation: <1ms per column, versus 100-200ms when calling grid.setColumns()
+* `grid.updateColumnHeaders`
+  * calls `grid.updateColumnHeader` for all columns
 * `grid.getId()` lets you get the uid of the grid instance
 * `grid.isGroupNode(row, cell)` lets you check if a node is part of a group row
 * Triggers existing event `onColumnsResized` when you change the column widths

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "main": [
     "slick.core.js",
     "slick.grid.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SlickGrid",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "scripts": {
     "build": "rollup -f iife -o slick.grid.js src/grid/index.js"
   },

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -624,6 +624,12 @@
       }
     }
 
+    function updateColumnHeaders() {
+      for (var i = 0; i < columns.length; i++) {
+        updateColumnHeader(columns[i].id);
+      }
+    }
+
     function unbindAncestorScrollEvents() {
       if (!$boundAncestors) {
         return;
@@ -654,6 +660,9 @@
 
         $header
           .attr("title", toolTip || "")
+          .removeClass($header.data("headerCssClass"))
+          .addClass(columnDef.headerCssClass || "")
+          .data("headerCssClass", columnDef.headerCssClass)
           .children().eq(0).html(title);
 
         trigger(self.onHeaderCellRendered, {
@@ -754,6 +763,7 @@
           .attr("title", m.toolTip || "")
           .data("column", m)
           .addClass(m.headerCssClass || "")
+          .data("headerCssClass", m.headerCssClass)
           .addClass(hiddenClass)
           .bind("dragstart", { distance: 3 }, function(e, dd) {
             trigger(self.onHeaderColumnDragStart, { "origEvent": e, "dragData": dd, "node": this, "columnIndex": getColumnIndexFromEvent(e) })
@@ -4009,6 +4019,7 @@
       "getColumnIndex": getColumnIndex,
       "getColumnNodeById": getColumnNodeById,
       "updateColumnHeader": updateColumnHeader,
+      "updateColumnHeaders": updateColumnHeaders,
       "refreshColumns": refreshColumns,
       "hideColumn": hideColumn,
       "unhideColumn": unhideColumn,

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -647,6 +647,12 @@ function SlickGrid(container, data, columns, options) {
     }
   }
 
+  function updateColumnHeaders() {
+    for (var i = 0; i < columns.length; i++) {
+      updateColumnHeader(columns[i].id);
+    }
+  }
+
   function unbindAncestorScrollEvents() {
     if (!$boundAncestors) {
       return;
@@ -677,6 +683,9 @@ function SlickGrid(container, data, columns, options) {
 
       $header
         .attr("title", toolTip || "")
+        .removeClass($header.data("headerCssClass"))
+        .addClass(columnDef.headerCssClass || "")
+        .data("headerCssClass", columnDef.headerCssClass)
         .children().eq(0).html(title);
 
       trigger(self.onHeaderCellRendered, {
@@ -777,6 +786,7 @@ function SlickGrid(container, data, columns, options) {
         .attr("title", m.toolTip || "")
         .data("column", m)
         .addClass(m.headerCssClass || "")
+        .data("headerCssClass", m.headerCssClass)
         .addClass(hiddenClass)
         .bind("dragstart", { distance: 3 }, function(e, dd) {
           trigger(self.onHeaderColumnDragStart, { "origEvent": e, "dragData": dd, "node": this, "columnIndex": getColumnIndexFromEvent(e) })
@@ -4032,6 +4042,7 @@ function SlickGrid(container, data, columns, options) {
     "getColumnIndex": getColumnIndex,
     "getColumnNodeById": getColumnNodeById,
     "updateColumnHeader": updateColumnHeader,
+    "updateColumnHeaders": updateColumnHeaders,
     "refreshColumns": refreshColumns,
     "hideColumn": hideColumn,
     "unhideColumn": unhideColumn,


### PR DESCRIPTION
same PR as before, but using `npm run build` flow

also bumping the minor version (3.7.0), since there was a small API change.
