### PR TITLE
change onGroupsChanged event to fire once at the top level

### DIFF
--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -530,12 +530,20 @@
         }
       }
 
-      if (groups.length > 0) {
-        onGroupsChanged.notify({groups: groups}, null, self);
-        groups.sort(groupingInfos[level].comparer);
+      return groups;
+    }
+
+    // (groups: Array[Object], parentGroup: Object) => void
+    function sortGroups(groups, parentGroup) {
+      for (var i = 0; i < groups.length; i++) {
+        var group = groups[i];
+        if (group.groups) {
+          sortGroups(group.groups, group);
+        }
       }
 
-      return groups;
+      var level = parentGroup ? parentGroup.level + 1 : 0;
+      groups.sort(groupingInfos[level].comparer);
     }
 
     function calculateTotals(totals) {
@@ -832,8 +840,11 @@
       groups = [];
       if (groupingInfos.length) {
         groups = extractGroups(newRows);
+
         if (groups.length) {
           addTotals(groups);
+          onGroupsChanged.notify({groups: groups}, null, self);
+          sortGroups(groups);
           newRows = flattenGroupedRows(groups);
         }
       }


### PR DESCRIPTION
At the moment, `onGroupsChanged` will fire for each and every set of groups in a group tree.  It's preferable to fire it once at the top level and let the consumer decide what to do with the entire tree.

Additionally, `dataView.getGroups()` will return an empty list in a `onGroupsChanged` event since the global groups array hasn't been assigned in the `extractGroups` method.  I think that consumers of this API would naturally expect that method to return the groups.

In addition, `onGroupsChanged` and group sorting will now execute after the `addTotals(groups)` call.  The `addTotals` call annotates additional information to each group such as whether it's collapsed or not (in addition to calculating totals objects).  This is considered a minimal risk since it only adds to the group object and doesn't mutate its existing properties.
