### PR TITLE
Revert "#27 - avoid calling updatePinnedColumns if the grid is not initially …"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,5 +128,3 @@ avoid layout thrashing on load.
 **Adds the `getData().getLengthWithoutGroupHeaders()` method.**
 
 **Adds the `enableColumnResize` option.**
-
-**Improves pinned column performance, by preventing two calls to setColumns for grids that are pinned**

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "slickgrid",
-  "version": "6.2.0",
+  "version": "6.1.0",
   "main": [
     "slick.core.js",
     "slick.grid.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SlickGrid",
-  "version": "6.2.0",
+  "version": "6.1.0",
   "scripts": {
     "build": "rollup -f iife -o slick.grid.js src/grid/index.js"
   },

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -385,13 +385,7 @@
 
       updateColumnCaches();
       createCssRules();
-      if (options.pinnedColumn) {
-        updatePinnedState();
-      } else {
-        topViewport.el.eq(1).hide();
-        contentViewportWrap.el.eq(1).hide();
-      }
-
+      updatePinnedState();
       setupColumnSort();
       resizeCanvas();
       updateAntiscroll();
@@ -1150,6 +1144,7 @@
         topViewport.el.eq(1).show();
         contentViewportWrap.el.eq(1).show();
       }
+      setScroller();
       setOverflow();
       createColumnHeaders();
       updateCanvasWidth();
@@ -2496,7 +2491,6 @@
     }
 
     function handleScroll(top) {
-      setScroller()
       scrollTop  = top || contentViewport.scroller.scrollTop;
       scrollLeft = contentViewport.scroller.scrollLeft;
       reallyHandleScroll(false);

--- a/src/grid/index.js
+++ b/src/grid/index.js
@@ -408,13 +408,7 @@ function SlickGrid(container, data, columns, options) {
 
     updateColumnCaches();
     createCssRules();
-    if (options.pinnedColumn) {
-      updatePinnedState();
-    } else {
-      topViewport.el.eq(1).hide();
-      contentViewportWrap.el.eq(1).hide();
-    }
-
+    updatePinnedState();
     setupColumnSort();
     resizeCanvas();
     updateAntiscroll();
@@ -1173,6 +1167,7 @@ function SlickGrid(container, data, columns, options) {
       topViewport.el.eq(1).show();
       contentViewportWrap.el.eq(1).show();
     }
+    setScroller();
     setOverflow();
     createColumnHeaders();
     updateCanvasWidth();
@@ -2519,7 +2514,6 @@ function SlickGrid(container, data, columns, options) {
   }
 
   function handleScroll(top) {
-    setScroller()
     scrollTop  = top || contentViewport.scroller.scrollTop;
     scrollLeft = contentViewport.scroller.scrollLeft;
     reallyHandleScroll(false);


### PR DESCRIPTION
Reverts coatue/SlickGrid#28

caused regression; reverting for now.
